### PR TITLE
Ignore pip warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.11-alpine
 
 COPY requirements.txt entrypoint.sh main.py /
 
+ENV PIP_ROOT_USER_ACTION=ignore
 RUN pip install -r requirements.txt && chmod +x entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
```
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
``` 